### PR TITLE
URL bug fix for apps in full screen mode.

### DIFF
--- a/science_apps_workspace.module
+++ b/science_apps_workspace.module
@@ -535,7 +535,7 @@ function science_app_view($node, $view_mode) {
                 '#suffix' => '</p>',
                 '#markup' => l(
                     t('Open %app in Full Screen', array('%app' => $node->title)),
-                    "app-embed/{$node->nid}",
+                    "app-embed/{$node->nid}/",
                     array(
                         'attributes' => array(
                             'class' => 'btn btn-primary btn-lg',
@@ -548,7 +548,7 @@ function science_app_view($node, $view_mode) {
             );
         } else {
             if ($fullscreen_pref == SCIENCE_APP_FULL_SCREEN_DEFAULT) {
-                $fullscreen_url = url("app-embed/{$node->nid}");
+                $fullscreen_url = url("app-embed/{$node->nid}/");
                 $node->content['options'] = array(
                     '#markup' => "<div class='app-options'><a href='$fullscreen_url' target='_blank' class='btn btn-info'><i class='fa fa-arrows-alt'></i> View App Full Screen</a></div>",
                     '#weight' => 9,


### PR DESCRIPTION
This pull request fixes a bug affecting BAR ePlant on Araport. The new code should add a "/" at the end of app-embed URLs so ePlant functions. This should not affect any other Science App.

Thanks,
Asher Pasha
Bioinformatician,
University of Toronto. 